### PR TITLE
Fix for on_config_changed behavior to actaully work on upgrading version.

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -77,8 +77,6 @@ class NodeExporterCharm(CharmBase):
 
     def _on_upgrade_charm(self, event):
         logger.debug("## Upgrading charm revision")
-        # Re-use config_changed logic to reset version and config
-        self._on_config_changed(event)
 
     def _on_start(self, event):
         logger.debug("## Starting node-exporter")

--- a/src/charm.py
+++ b/src/charm.py
@@ -191,4 +191,3 @@ def _render_sysconfig(context: dict) -> None:
 
 if __name__ == "__main__":
     main(NodeExporterCharm)
-


### PR DESCRIPTION
- Moved user/group & service creation to separate functions.
- Created a on-time setup _on_install that runs through all steps.
- Added and change _on_config_changed to actaully re-download and replace binary only if version is changed, restarts the service and re-rendering sysconfig if needed.
- Added version tracking.